### PR TITLE
[ISSUE-3] Cache by entity and constraint definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,6 @@ format:
 
 test:
 	pytest -vv
+
+test-coverage:
+	pytest --cov-report term --cov=src

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make init
 
 ### Testing
 
-To run unit test:
+To run unit tests:
 
 ```bash
 make test

--- a/README.md
+++ b/README.md
@@ -36,9 +36,18 @@ make init
 
 ### Testing
 
+To run unit test:
+
 ```bash
 make test
 ```
+
+With code coverage:
+
+```back
+make test-coverage
+```
+
 
 ### Linting
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ With code coverage:
 make test-coverage
 ```
 
-
 ### Linting
 
 ```bash

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,5 +1,6 @@
-flake8>=3.8.3
-mypy>=0.782
-black>=19.10b0
-pytest>=6.0.1
-pymatrix>=3.0.1
+black==19.10b0
+flake8==3.8.3
+mypy==0.782
+pymatrix==3.0.1
+pytest-cov==2.10.1
+pytest==6.0.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="slvstopy",
-    version="0.0.3",
+    version="0.0.4",
     url="https://github.com/kktse/slvstopy",
     author="Kelvin Tse",
     classifiers=[

--- a/src/slvstopy/__init__.py
+++ b/src/slvstopy/__init__.py
@@ -38,12 +38,12 @@ class Slvstopy:
         )
 
         # Assumption: first nine entities are reference entities
-        reference_entity_definitions = entity_definition[0:9]
-        entity_definitions = entity_definition[9:]
+        reference_entity_definition = entity_definition[0:9]
+        mechanism_entity_definition = entity_definition[9:]
 
-        entity_service.construct_entities(reference_entity_definitions)
+        entity_service.construct_entities(reference_entity_definition)
         entity_service.set_group_number(entity_service.get_group_number() + 1)
-        entity_service.construct_entities(entity_definitions)
+        entity_service.construct_entities(mechanism_entity_definition)
 
         constraint_service.construct_constraints(constraint_definition)
 

--- a/src/slvstopy/__init__.py
+++ b/src/slvstopy/__init__.py
@@ -16,18 +16,18 @@ class Slvstopy:
     def __init__(self, file_path: str = "", file_handle: TextIO = None):
         if file_path:
             with open(file_path, encoding="utf8", errors="ignore") as f:
-                self.lines = self._read_lines_from_file(f)
+                lines = self._read_lines_from_file(f)
         else:
-            self.lines = self._read_lines_from_file(f)
+            lines = self._read_lines_from_file(f)
+
+        self.entity_definition, self.constraint_definition = self._parse_elements(lines)
 
     def generate_system(self) -> Tuple[SolverSystem, Dict[str, Entity]]:
-        return self._generate_system(self.lines)
+        return self._generate_system(self.entity_definition, self.constraint_definition)
 
     def _generate_system(
-        self, file_lines: List[str]
+        self, entity_definition: List[Dict], constraint_definition: List[Dict],
     ) -> Tuple[SolverSystem, Dict[str, Entity]]:
-        entity_definitions, constraint_definitions = self._parse_elements(file_lines)
-
         sys = SolverSystem()
         entity_repository = EntityRepository(system=sys)
         entity_service = EntityService(entity_repository=entity_repository)
@@ -38,21 +38,21 @@ class Slvstopy:
         )
 
         # Assumption: first nine entities are reference entities
-        reference_entity_definitions = entity_definitions[0:9]
-        entity_definitions = entity_definitions[9:]
+        reference_entity_definitions = entity_definition[0:9]
+        entity_definitions = entity_definition[9:]
 
         entity_service.construct_entities(reference_entity_definitions)
         entity_service.set_group_number(entity_service.get_group_number() + 1)
         entity_service.construct_entities(entity_definitions)
 
-        constraint_service.construct_constraints(constraint_definitions)
+        constraint_service.construct_constraints(constraint_definition)
 
         return sys, entity_repository.entities
 
     def _read_lines_from_file(self, handle: TextIO) -> List[str]:
         return handle.read().splitlines()
 
-    def _parse_elements(self, file_lines: List[str]):
+    def _parse_elements(self, file_lines: List[str]) -> Tuple[List, List]:
         sv: dict = {}
         entities = []
         constraints = []


### PR DESCRIPTION
## Changes

* Addresses #3 
* Cache the parsed entity and constraint definitions at file read
* Lock the requirements
* Add code coverage
* Bump version

## Benchmarking
For the RSX rear suspension case. The motion is defined as `range(-50, 110, 5)`. Single threaded.

Before:
```
%timeit result = solver.solve_motion(MOTION)
1.02 s ± 11.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

After:
```
%timeit result = solver.solve_motion(MOTION)
755 ms ± 2.75 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

* 25% ms per loop reduction
* 76% ms per loop variance reduction