### PR TITLE
Lock python-solvespace to 3.0.2

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,2 @@
 Cython>=0.29.15
-python-solvespace>=3.0.2
+python-solvespace==3.0.2

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="slvstopy",
-    version="0.0.4",
+    version="0.0.5",
     url="https://github.com/kktse/slvstopy",
     author="Kelvin Tse",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     python_requires=">3.6",
-    install_requires=["Cython>=0.29.15", "python-solvespace>=3.0.2"],
+    install_requires=["Cython>=0.29.15", "python-solvespace==3.0.2"],
     license="MPL2",
 )


### PR DESCRIPTION
I was unable to build `python-solvepace==3.0.6`, so we are locking the version to one that I wrote this library for.